### PR TITLE
add ability to provide custom images

### DIFF
--- a/htck/app/index.html
+++ b/htck/app/index.html
@@ -63,6 +63,7 @@
     <script src="scripts/services/tools.js"></script>
     <script src="scripts/services/save.js"></script>
     <script src="scripts/services/pages.js"></script>
+    <script src="scripts/services/custom.js"></script>
     <!-- endbuild -->
 
     <script>

--- a/htck/app/scripts/controllers/main.js
+++ b/htck/app/scripts/controllers/main.js
@@ -3,7 +3,7 @@
 /* globals constants */
 /* globals Raphael */
 /* globals $ */
-angular.module('htckApp').controller('MainCtrl', function ($scope, $timeout, $log, $document, $mdSidenav, hExport, hTextEdit, hHotkeys, hElement, hTools, hSave, hPages) {
+angular.module('htckApp').controller('MainCtrl', function ($scope, $timeout, $log, $document, $mdSidenav, hExport, hTextEdit, hHotkeys, hElement, hTools, hSave, hPages, hCustom) {
   		$scope.constants = constants;
 
       $scope.setCurrent = function(newCurrent) {
@@ -327,6 +327,16 @@ angular.module('htckApp').controller('MainCtrl', function ($scope, $timeout, $lo
         }
       };
 
+      $scope.addCustomImage = function(){
+        $log.debug('Add custom image');
+        hCustom.addCustomImage().then($scope.$applyAsync());
+      };
+
+      $scope.clearCustomImages = function(){
+        $log.debug('Clear custom images');
+        hCustom.clearCustomImages();
+      };
+
       $scope.export = function(){
         $log.debug('Exporting');
         // Unfocus to remove handles from elements
@@ -445,6 +455,7 @@ angular.module('htckApp').controller('MainCtrl', function ($scope, $timeout, $lo
         hSave.init($scope);
         hHotkeys($scope);
         hPages.init($scope);
+        hCustom.init($scope);
 
         $scope.hPages = hPages;
 

--- a/htck/app/scripts/services/custom.js
+++ b/htck/app/scripts/services/custom.js
@@ -1,0 +1,55 @@
+'use strict';
+
+angular.module('htckApp').factory('hCustom', function () {
+  const CUSTOM_IMAGES_KEY = '_customImages';
+  var scope = {};
+
+  function init(parent) {
+    scope = parent.$new();
+    loadCustomImages();
+  }
+
+  function addCustomImage() {
+    return showOpenFilePicker({
+      types: [{
+        accept: {
+          'image/jpeg': ['.jpg', '.jpeg'],
+          'image/png': ['.png']
+        }
+      }]
+    }).then(files => {
+      for (const file of files) {
+        file.getFile().then(blob => {
+          var reader = new FileReader();
+          reader.readAsDataURL(blob); 
+          reader.onloadend = () => {
+            var base64data = reader.result;
+            scope.$parent.customImages.push(base64data);
+            saveCustomImages();
+          };
+      });
+    }});
+  }
+
+  function clearCustomImages() {
+    const shouldClear = confirm('Remove all custom images?');
+    if (shouldClear) {
+      scope.$parent.customImages = [];
+      saveCustomImages();
+    }
+  }
+
+  function loadCustomImages() {
+    scope.$parent.customImages = JSON.parse(sessionStorage.getItem(CUSTOM_IMAGES_KEY)) || [];
+  }
+
+  function saveCustomImages() {
+    sessionStorage.setItem(CUSTOM_IMAGES_KEY, JSON.stringify(scope.$parent.customImages));
+  }
+
+  return {
+    addCustomImage,
+    clearCustomImages,
+    init
+  };
+});

--- a/htck/app/styles/app.scss
+++ b/htck/app/styles/app.scss
@@ -126,11 +126,15 @@ md-tabs-wrapper {
   color: white;
 }
 
-#toolbar-general, #toolbar-pages {
+#toolbar-general, #toolbar-pages, #toolbar-custom {
   background-image: url(../images/background_3.jpg);
   margin-top: 15px;
   height:$toolbarHeight;
   vertical-align:top;
+}
+
+#toolbar-custom {
+  margin-bottom: 15px;
 }
 
 .toolbar-text {

--- a/htck/app/views/main.html
+++ b/htck/app/views/main.html
@@ -27,6 +27,32 @@
                 </div>
               </md-content>
             </md-tab>
+            <md-tab label="Custom">
+              <md-content class="md-padding">
+                <div id="toolbar-custom">
+                  <md-button class="md-icon-button" aria-label="Add custom image" ng-click="addCustomImage()">
+                    <md-icon class="fa fa-upload"></md-icon>
+                    <md-tooltip md-delay="::constants.TOOLTIP_DELAY">Add custom image</md-tooltip>
+                  </md-button>
+            
+                  <md-button class="md-icon-button" aria-label="Clear custom images" ng-click="clearCustomImages()">
+                    <md-icon class="fa fa-trash"></md-icon>
+                    <md-tooltip md-delay="::constants.TOOLTIP_DELAY">Clear custom images</md-tooltip>
+                  </md-button>
+                </div>
+                <div>
+                  <md-grid-list
+                    md-cols-sm="1" md-cols-md="2" md-cols-gt-md="3"
+                    md-row-height-gt-md="2:2" md-row-height="2:2"
+                    md-gutter="12px" md-gutter-gt-sm="8px" >
+                    <md-grid-tile ng-repeat="i in customImages track by $index" class="gray background-bank-item"
+                      md-rowspan="1" md-colspan="1" md-colspan-sm="1">
+                      <img class="item" data-drag="true" jqyoui-draggable="{animate: true}" data-jqyoui-options="{revert: 'invalid', appendTo: 'body', containment: 'window', scroll: false, helper: 'clone'}" ng-src="{{::i}}" ng-click="addImage(i)"></img>
+                    </md-grid-tile>
+                  </md-grid-list>
+                </div>
+              </md-content>
+            </md-tab>
             <md-tab label="Backgrounds" ng-if="::constants.backgrounds.length > 1">
               <md-content class="md-padding">
                 <div>


### PR DESCRIPTION
* adds a "custom" tab to image selection sidebar
  * allows adding and removing custom images
  * images are saved in browser `sessionStorage` as base64 strings and persist through page refresh/reload

quick demo:
https://github.com/htck/bayeux/assets/42639252/ab643d69-28da-43b5-9d36-b638ff2f635b

